### PR TITLE
fix: Google Gemini SDK callers - fix method prefix, signature and key names (v0.3.2)

### DIFF
--- a/.kilo/kilo.jsonc
+++ b/.kilo/kilo.jsonc
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://app.kilo.ai/config.json"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ideal-ai"
-version = "0.3.1"
+version = "0.3.2"
 description = "The Universal Python LLM Connector. Unified API for ChatGPT, Ollama, DeepSeek, Gemini & Qwen. Native Multimodal support (Text, Vision, Audio, Video) for building AI Agents. 100% Open Source."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ideal_ai/__init__.py
+++ b/src/ideal_ai/__init__.py
@@ -7,7 +7,7 @@ Supports text generation, vision, audio transcription, speech synthesis, image a
 
 from ideal_ai.connector import IdealUniversalLLMConnector, IdealSmolagentsWrapper
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "Gilles Blanchet"
 __license__ = "Apache-2.0"
 

--- a/src/ideal_ai/connector.py
+++ b/src/ideal_ai/connector.py
@@ -1235,14 +1235,21 @@ class IdealUniversalLLMConnector:
     # CALLERS (Used by families)
     # ====================================================================
 
-    def call_google_sdk_text(self, payload: dict, context) -> Any:
+    def _call_google_sdk_text(self, payload: dict, **context) -> Any:
         """Call Google Gemini SDK text-only."""
         if not genai_client:
             raise ImportError("Please install google-genai: pip install google-genai")
-        apikey = context.get("apikey")
-        if not apikey:
-            raise ValueError("Gemini API key missing expected in resolved config")
-        client = genai_client.Client(api_key=apikey)
+
+        api_key = context.get("api_key") or os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            raise ValueError("Gemini API key missing (api_key or GEMINI_API_KEY).")
+
+        model_id = context.get("model_id")
+        if not model_id:
+            raise ValueError("model_id missing in Google SDK context.")
+
+        client = genai_client.Client(api_key=api_key)
+
         messages_list = payload.get("messages", [])
         last = None
         if isinstance(messages_list, list):
@@ -1253,11 +1260,13 @@ class IdealUniversalLLMConnector:
                 elif isinstance(msg, str):
                     last = msg
                     break
+
         if not last:
-            raise ValueError("No user message found for Gemini.")
+            raise ValueError("No user message found for Gemini text call.")
+
         response = client.models.generate_content(
-            model=context.get("modelid"),
-            contents=last
+            model=model_id,
+            contents=last,
         )
         return response
 
@@ -1312,20 +1321,28 @@ class IdealUniversalLLMConnector:
             
         return response.json()
 
-    def call_google_sdk_vision(self, payload: dict, context) -> Any:
+    def _call_google_sdk_vision(self, payload: dict, **context) -> Any:
         """Call Google Gemini SDK with multimodal content."""
         if not genai_client:
             raise ImportError("Please install google-genai: pip install google-genai")
-        apikey = context.get("apikey")
-        if not apikey:
-            raise ValueError("Gemini API key missing expected in resolved config")
-        client = genai_client.Client(api_key=apikey)
-        contentlist = payload.get("content")
-        if not contentlist or len(contentlist) < 2:
+
+        api_key = context.get("api_key") or os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            raise ValueError("Gemini API key missing (api_key or GEMINI_API_KEY).")
+
+        model_id = context.get("model_id")
+        if not model_id:
+            raise ValueError("model_id missing in Google SDK context.")
+
+        client = genai_client.Client(api_key=api_key)
+
+        content_list = payload.get("content")
+        if not content_list or len(content_list) < 2:
             raise ValueError(f"Invalid vision payload for Gemini. Received: {payload}")
+
         response = client.models.generate_content(
-            model=context.get("modelid"),
-            contents=contentlist
+            model=model_id,
+            contents=content_list,
         )
         return response
 


### PR DESCRIPTION
- `_call_google_sdk_text` and `_call_google_sdk_vision`: missing `_` prefix on method name
- Fixed signature: `context` → `**context`
- Fixed key names: `api_key` and `model_id`
- Compatible with modern `google-genai` SDK