### PR TITLE
chore: remove local Kilo config from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dmypy.json
 # Décommenter si vous voulez ignorer les lock files
 # poetry.lock
 # requirements.lock
+.kilo/

--- a/.kilo/kilo.jsonc
+++ b/.kilo/kilo.jsonc
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://app.kilo.ai/config.json"
-}


### PR DESCRIPTION
- remove `.kilo/kilo.jsonc` from the repository
- add `.kilo/` to `.gitignore`
- keep local editor config out of the public repo